### PR TITLE
Fix the mac80211 backport not to remove the dependencies on kmod-cryp…

### DIFF
--- a/patches/openwrt/0006-mac80211-backport-from-trunk-r47249.patch
+++ b/patches/openwrt/0006-mac80211-backport-from-trunk-r47249.patch
@@ -3,7 +3,7 @@ Date: Tue, 23 Dec 2014 18:57:16 +0100
 Subject: mac80211: backport from trunk r47249
 
 diff --git a/package/kernel/mac80211/Makefile b/package/kernel/mac80211/Makefile
-index a1eedce..f332cbd 100644
+index a1eedce..566e156 100644
 --- a/package/kernel/mac80211/Makefile
 +++ b/package/kernel/mac80211/Makefile
 @@ -10,11 +10,11 @@ include $(INCLUDE_DIR)/kernel.mk
@@ -66,15 +66,6 @@ index a1eedce..f332cbd 100644
  endef
  
  define KernelPackage/cfg80211
-@@ -79,7 +91,7 @@ endef
- define KernelPackage/mac80211
-   $(call KernelPackage/mac80211/Default)
-   TITLE:=Linux 802.11 Wireless Networking Stack
--  DEPENDS+= +kmod-crypto-core +kmod-crypto-arc4 +kmod-crypto-aes +kmod-cfg80211 +hostapd-common
-+  DEPENDS+= +kmod-cfg80211 +hostapd-common
-   KCONFIG:=\
- 	CONFIG_AVERAGE=y
-   FILES:= $(PKG_BUILD_DIR)/net/mac80211/mac80211.ko
 @@ -109,8 +121,8 @@ Generic IEEE 802.11 Networking Stack (mac80211)
  endef
  

--- a/patches/openwrt/0034-ath10k-add-Candelatech-community-firmware-as-an-additional-choice.patch
+++ b/patches/openwrt/0034-ath10k-add-Candelatech-community-firmware-as-an-additional-choice.patch
@@ -3,7 +3,7 @@ Date: Tue, 10 Mar 2015 13:17:14 +0100
 Subject: ath10k: add Candelatech community firmware as an additional choice
 
 diff --git a/package/kernel/mac80211/Makefile b/package/kernel/mac80211/Makefile
-index f332cbd..28f40c8 100644
+index 566e156..1dc1816 100644
 --- a/package/kernel/mac80211/Makefile
 +++ b/package/kernel/mac80211/Makefile
 @@ -270,6 +270,29 @@ Atheros IEEE 802.11ac family of chipsets. For now only


### PR DESCRIPTION
…to-arc4 and kmod-crypto-aes

The trunk version of mac80211 doesn't need these dependencies anymore as
they are compiled into the kernel.

While this didn't cause any issues for Gluon as we always build the kernel
with all modules, this fix makes the patch work on a plain OpenWrt CC as
well.